### PR TITLE
Fix makeCurlHeadersArray: sanitize headers to prevent 400 Bad Request

### DIFF
--- a/REDCapREST.php
+++ b/REDCapREST.php
@@ -203,7 +203,7 @@ class REDCapREST extends AbstractExternalModule {
         $systemTokens = $this->getSubSettings('token-management');
         foreach ($systemTokens as $i => $systemToken) {
             if (  array_key_exists(1, $matches) && $matches[1]==$systemToken['token-ref'] &&
-                  starts_with($this->destURL, $systemToken['token-url']) ) {
+                starts_with($this->destURL, $systemToken['token-url']) ) {
                 $found = true;
                 break;
             }
@@ -251,17 +251,51 @@ class REDCapREST extends AbstractExternalModule {
         if (empty(trim($instructionContentType))) $instructionContentType = 'application/json';
         return $instructionContentType;
     }
-    
-    protected function makeCurlHeadersArray($instructionCurlHeaders='') {
-        if (empty(trim($instructionCurlHeaders))) return array();
+
+    protected function makeCurlHeadersArray($instructionCurlHeaders = '')
+    {
+        // Build a sanitized header list from the EM config, skipping hop-by-hop/problematic headers.
+        if (empty(trim($instructionCurlHeaders)))
+            return array();
+
         $headers = array();
-        $lines = explode('\n', $instructionCurlHeaders);
+        $lines = explode("\n", $instructionCurlHeaders);
+
+        // Never forward these explicitly; cURL/Apache will handle them.
+        $blocked = array('content-length', 'connection', 'transfer-encoding', 'expect');
+
         foreach ($lines as $line) {
-            $headers[] = $this->pipe($line);
+            $line = trim($line);
+            if ($line === '')
+                continue;
+
+            // Piping (RedCap variables)
+            $line = $this->pipe($line);
+
+            // Normalize spaces and remove CR/LF
+            $line = str_replace(array("\r", "\n"), ' ', $line);
+            $line = preg_replace('/\s+/', ' ', $line);
+
+            // Split "Name: Value"
+            $parts = explode(':', $line, 2);
+            if (count($parts) !== 2)
+                continue;
+
+            $name = trim($parts[0]);
+            $value = trim($parts[1]);
+            if ($name === '')
+                continue;
+
+            if (in_array(strtolower($name), $blocked, true))
+                continue;
+
+            $headers[] = $name . ': ' . $value;
         }
+
         return $headers;
     }
-    
+
+
     protected function makeCurlOptionsArray($instructionCurlOptions='') {
         if (empty(trim($instructionCurlOptions))) return array();
 


### PR DESCRIPTION
## Summary
This patch updates the `makeCurlHeadersArray` function to sanitize and normalize request headers before sending them via cURL.  
The original implementation forwarded all headers, including hop-by-hop/problematic ones (e.g. `Content-Length`, `Connection`), which could cause `400 Bad Request` errors in some environments.

## Changes
- Filter out problematic headers:  
  - `Content-Length`  
  - `Connection`  
  - `Transfer-Encoding`  
  - `Expect`
- Normalize headers by stripping CR/LF and extra whitespace.  
- Ensure only valid `Name: Value` pairs are included.  
- Preserve critical headers such as `Content-Type: application/json`.

## Testing
- Verified against environments running:
  - CentOS 7 with cURL 7.29 (NSS)
  - Ubuntu 24.04 with cURL 8.x (OpenSSL)
- Confirmed requests are now accepted by external APIs that require JSON payloads.  
- Regression tested with existing REDCap REST calls to ensure no functionality is broken.

## Notes
- This fix prevents malformed or duplicate headers from being sent to external APIs.  
- No configuration changes required for end users.  
- Recommended for inclusion in the next release to ensure wider compatibility across both legacy and modern server environments.