### PR TITLE
Fixes and enhancements for OAuth2 Client Credentials

### DIFF
--- a/OAuth2.php
+++ b/OAuth2.php
@@ -55,7 +55,7 @@ abstract class OAuth2 {
     protected function saveAccessToken() {
         $cache = json_decode($this->instruction['oauth2-cache'], true);
         $cache['access_token'] = $this->access_token;
-        $cache['access_token_expiry'] = $this->access_token_expiry->format('Y-m-i H:i:s');
+        $cache['access_token_expiry'] = $this->access_token_expiry->format('Y-m-d H:i:s');
 
         $projectSetting = $this->module->getProjectSetting("oauth2-cache");
         $projectSetting[$this->instruction_index] = json_encode($cache, JSON_FORCE_OBJECT);

--- a/OAuth2ClientCredentials.php
+++ b/OAuth2ClientCredentials.php
@@ -6,20 +6,27 @@
  */
 namespace MCRI\REDCapREST;
 
-abstract class OAuth2ClientCredentials extends OAuth2 {
+class OAuth2ClientCredentials extends OAuth2 {
 
-    public function oauth2Call(string $method, string $url, string $contentType, array $headers, array $curlOptions, string $payload, $allowRetry=false): void {
+    public function oauth2Call(string $method, string $url, string $contentType, array $headers, array $curlOptions, string $payload, $allowRetry=true): void {
         // update access token if needed (first connection or expired)
         $this->updateAccessToken();
 
-        $headers[] = "Authorization: Bearer ".$this->access_token;
+        $authHeaders = $headers;
+        $authHeaders[] = "Authorization: Bearer ".$this->access_token;
 
-        list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $headers, $curlOptions, $payload, true);
+        list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $authHeaders, $curlOptions, $payload);
         
         if ($this->info['http_code'] === 401 && $allowRetry) {
             // retry once with new token
             $this->access_token = null;
-            list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $headers, $curlOptions, $payload, false);
+            $this->access_token_expiry = null;
+            $this->updateAccessToken();
+
+            $authHeaders = $headers;
+            $authHeaders[] = "Authorization: Bearer ".$this->access_token;
+
+            list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $authHeaders, $curlOptions, $payload);
         }
     }
 
@@ -37,11 +44,11 @@ abstract class OAuth2ClientCredentials extends OAuth2 {
 
         // obtain an access token
         $payload = http_build_query(array('grant_type' => 'client_credentials'));
-        $curlOptions = array(CURLOPT_USERPWD, $this->client_id.":".$this->client_secret);
+        $curlOptions = array(array(CURLOPT_USERPWD, $this->client_id.":".$this->client_secret));
 
         list($response, $info) = $this->module->curlCall('POST', $this->token_endpoint, 'application/x-www-form-urlencoded', array(), $curlOptions, $payload);
 
-        if (!isset($info['http_code']) && $info['http_code'] !== 200) {
+        if (!isset($info['http_code']) || $info['http_code'] !== 200) {
             throw new \Exception('Unable to obtain access token');
         }
 

--- a/REDCapREST.php
+++ b/REDCapREST.php
@@ -379,6 +379,7 @@ class REDCapREST extends AbstractExternalModule {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, self::MODULE_TITLE);
         if ($GLOBALS['is_development_server']) curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
         foreach ($curlOptions as $opt) {

--- a/REDCapREST.php
+++ b/REDCapREST.php
@@ -75,7 +75,7 @@ class REDCapREST extends AbstractExternalModule {
                 return;
             }
 
-            switch ($instruction['oauth2-config']) {
+            switch ($instruction['oauth2-option']) {
                 case 'client-credentials':
                     // oauth2 connection required
                     try {
@@ -406,6 +406,7 @@ class REDCapREST extends AbstractExternalModule {
 
         $response = curl_exec($ch);
         $info = curl_getinfo($ch);
+        curl_close($ch);
 
         $this->log('cURL info: '.json_encode($info)); // log response info useful for debugging responses
         

--- a/config.json
+++ b/config.json
@@ -162,8 +162,8 @@
                     "key": "oauth2-option",
                     "required": false,
                     "type": "dropdown",
-                    "chocies": [
-                        { "value": "client-credentials", "label": "Client Credentials"}
+                    "choices": [
+                        { "value": "client-credentials", "name": "Client Credentials"}
                     ]
                 },
                 {
@@ -176,7 +176,7 @@
                     "name": "OAuth2 storage cache",
                     "key": "oauth2-cache",
                     "required": false,
-                    "hidden": false,
+                    "hidden": true,
                     "type": "textarea"
                 },
                 {


### PR DESCRIPTION
# Fixes and enhancements for OAuth2 Client Credentials

## Summary

Thank you for building out the OAuth2 Client Credentials support — this is exactly what we need for our use case. We've been working through the implementation to get it ready for testing against our target API and found a few issues along the way. This PR collects those fixes.

We also added a default `User-Agent` header since the API we're integrating with requires one.

## Changes

### Routing to the OAuth2 path

The switch in `redcap_save_record` was checking `$instruction['oauth2-config']` (the JSON textarea) rather than `$instruction['oauth2-option']` (the dropdown). Updated to use the dropdown key.

### Class instantiation

`OAuth2ClientCredentials` was marked `abstract`, which prevented it from being instantiated. Removed the modifier.

### Token endpoint response check

The condition in `updateAccessToken()` used `&&` where `||` was needed — when `http_code` is present (the normal case), a non-200 response was passing through silently:
```php
// Was:
if (!isset($info['http_code']) && $info['http_code'] !== 200)

// Now:
if (!isset($info['http_code']) || $info['http_code'] !== 200)
```

### cURL options structure

The `CURLOPT_USERPWD` option for the token request was a flat array rather than the nested pair format that `curlCall()` expects. Wrapped it in an outer array to match.

### 401 retry flow

After receiving a 401, the retry path needed to fetch a fresh token and rebuild the Authorization header. Updated to call `updateAccessToken()` after clearing the cached token, and to construct a new headers array so the stale Bearer value isn't reused.

### Date format in `saveAccessToken()`

The format string used `'Y-m-i'` where `i` is minutes in PHP's date formatting. Changed to `'Y-m-d'`.

### Config dropdown definition

The OAuth2 type dropdown had a small typo (`chocies` → `choices`) and used `label` instead of `name` for the option text.

### Cache field visibility

Set `oauth2-cache` to `"hidden": true` since it's internal storage.

### Resource cleanup

Restored `curl_close($ch)` in the refactored `curlCall()` method.

## Enhancement: Default User-Agent

Added `CURLOPT_USERAGENT` set to the module title in `curlCall()`. This applies to all outbound requests including token fetches. It can still be overridden per-message through the cURL Options config field.

## Files changed

| File | Changes |
|---|---|
| `REDCapREST.php` | oauth2-option switch, User-Agent, curl_close() |
| `OAuth2ClientCredentials.php` | Class modifier, status check, cURL options, retry logic |
| `OAuth2.php` | Date format |
| `config.json` | Dropdown definition, cache visibility |

## Testing

We wrote PHPUnit tests covering token acquisition, caching/expiry, retry logic, and error handling (available separately if you're interested).
