### PR TITLE
Add PHPUnit tests for OAuth2 Client Credentials flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 test.txt
+vendor/
+composer.lock
+.phpunit.cache/

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -55,7 +55,7 @@ abstract class OAuth2 {
     protected function saveAccessToken() {
         $cache = json_decode($this->instruction['oauth2-cache'], true);
         $cache['access_token'] = $this->access_token;
-        $cache['access_token_expiry'] = $this->access_token_expiry->format('Y-m-i H:i:s');
+        $cache['access_token_expiry'] = $this->access_token_expiry->format('Y-m-d H:i:s');
 
         $projectSetting = $this->module->getProjectSetting("oauth2-cache");
         $projectSetting[$this->instruction_index] = json_encode($cache, JSON_FORCE_OBJECT);

--- a/OAuth2ClientCredentials.php
+++ b/OAuth2ClientCredentials.php
@@ -6,20 +6,27 @@
  */
 namespace MCRI\REDCapREST;
 
-abstract class OAuth2ClientCredentials extends OAuth2 {
+class OAuth2ClientCredentials extends OAuth2 {
 
-    public function oauth2Call(string $method, string $url, string $contentType, array $headers, array $curlOptions, string $payload, $allowRetry=false): void {
+    public function oauth2Call(string $method, string $url, string $contentType, array $headers, array $curlOptions, string $payload, $allowRetry=true): void {
         // update access token if needed (first connection or expired)
         $this->updateAccessToken();
 
-        $headers[] = "Authorization: Bearer ".$this->access_token;
+        $authHeaders = $headers;
+        $authHeaders[] = "Authorization: Bearer ".$this->access_token;
 
-        list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $headers, $curlOptions, $payload, true);
+        list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $authHeaders, $curlOptions, $payload);
         
         if ($this->info['http_code'] === 401 && $allowRetry) {
             // retry once with new token
             $this->access_token = null;
-            list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $headers, $curlOptions, $payload, false);
+            $this->access_token_expiry = null;
+            $this->updateAccessToken();
+
+            $authHeaders = $headers;
+            $authHeaders[] = "Authorization: Bearer ".$this->access_token;
+
+            list($this->response, $this->info) = $this->module->curlCall($method, $url, $contentType, $authHeaders, $curlOptions, $payload);
         }
     }
 
@@ -37,11 +44,11 @@ abstract class OAuth2ClientCredentials extends OAuth2 {
 
         // obtain an access token
         $payload = http_build_query(array('grant_type' => 'client_credentials'));
-        $curlOptions = array(CURLOPT_USERPWD, $this->client_id.":".$this->client_secret);
+        $curlOptions = array(array(CURLOPT_USERPWD, $this->client_id.":".$this->client_secret));
 
         list($response, $info) = $this->module->curlCall('POST', $this->token_endpoint, 'application/x-www-form-urlencoded', array(), $curlOptions, $payload);
 
-        if (!isset($info['http_code']) && $info['http_code'] !== 200) {
+        if (!isset($info['http_code']) || $info['http_code'] !== 200) {
             throw new \Exception('Unable to obtain access token');
         }
 

--- a/REDCapREST.php
+++ b/REDCapREST.php
@@ -379,6 +379,7 @@ class REDCapREST extends AbstractExternalModule {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, self::MODULE_TITLE);
         if ($GLOBALS['is_development_server']) curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
         foreach ($curlOptions as $opt) {

--- a/REDCapREST.php
+++ b/REDCapREST.php
@@ -75,7 +75,7 @@ class REDCapREST extends AbstractExternalModule {
                 return;
             }
 
-            switch ($instruction['oauth2-config']) {
+            switch ($instruction['oauth2-option']) {
                 case 'client-credentials':
                     // oauth2 connection required
                     try {
@@ -406,6 +406,7 @@ class REDCapREST extends AbstractExternalModule {
 
         $response = curl_exec($ch);
         $info = curl_getinfo($ch);
+        curl_close($ch);
 
         $this->log('cURL info: '.json_encode($info)); // log response info useful for debugging responses
         

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "mcri/redcap-rest",
+    "description": "REDCap External Module: Trigger API calls on form save",
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
+    "autoload": {
+        "classmap": [
+            "REDCapREST.php",
+            "OAuth2.php",
+            "OAuth2ClientCredentials.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MCRI\\REDCapREST\\Tests\\": "tests/"
+        }
+    }
+}

--- a/config.json
+++ b/config.json
@@ -162,8 +162,8 @@
                     "key": "oauth2-option",
                     "required": false,
                     "type": "dropdown",
-                    "chocies": [
-                        { "value": "client-credentials", "label": "Client Credentials"}
+                    "choices": [
+                        { "value": "client-credentials", "name": "Client Credentials"}
                     ]
                 },
                 {
@@ -176,7 +176,7 @@
                     "name": "OAuth2 storage cache",
                     "key": "oauth2-cache",
                     "required": false,
-                    "hidden": false,
+                    "hidden": true,
                     "type": "textarea"
                 },
                 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="OAuth2">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/OAuth2ClientCredentialsTest.php
+++ b/tests/OAuth2ClientCredentialsTest.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * Tests for OAuth2ClientCredentials
+ *
+ * These tests mock REDCapREST::curlCall() and REDCapREST::pipeApiToken()
+ * to verify the OAuth2 Client Credentials flow in isolation from REDCap.
+ */
+namespace MCRI\REDCapREST\Tests;
+
+use PHPUnit\Framework\TestCase;
+use MCRI\REDCapREST\REDCapREST;
+use MCRI\REDCapREST\OAuth2ClientCredentials;
+
+require_once __DIR__ . '/../OAuth2.php';
+require_once __DIR__ . '/../OAuth2ClientCredentials.php';
+require_once __DIR__ . '/../REDCapREST.php';
+
+class OAuth2ClientCredentialsTest extends TestCase
+{
+    private function makeInstruction(array $overrides = []): array
+    {
+        $config = json_encode([
+            'auth-url'      => 'https://auth.example.com/token',
+            'client-id'     => 'test-client-id',
+            'client-secret' => 'test-client-secret',
+        ]);
+
+        return array_merge([
+            'oauth2-config' => $config,
+            'oauth2-cache'  => '{}',
+        ], $overrides);
+    }
+
+    private function makeTokenResponse(string $token = 'fresh-token', int $expiresIn = 3600): string
+    {
+        return json_encode([
+            'access_token' => $token,
+            'expires_in'   => $expiresIn,
+        ]);
+    }
+
+    private function makeMockModule(): REDCapREST
+    {
+        $mock = $this->getMockBuilder(REDCapREST::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['curlCall', 'pipeApiToken', 'getProjectSetting', 'setProjectSetting', 'log'])
+            ->getMock();
+
+        // pipeApiToken returns the string unchanged by default (no token-ref placeholders in tests)
+        $mock->method('pipeApiToken')
+            ->willReturnArgument(0);
+
+        // getProjectSetting returns an empty array for oauth2-cache
+        $mock->method('getProjectSetting')
+            ->willReturn([]);
+
+        return $mock;
+    }
+
+    // ---------------------------------------------------------------
+    // Token acquisition
+    // ---------------------------------------------------------------
+
+    public function testFetchesNewTokenWhenCacheIsEmpty(): void
+    {
+        $module = $this->makeMockModule();
+
+        // First call: token endpoint returns a token
+        // Second call: the actual API call succeeds
+        $module->expects($this->exactly(2))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse('new-token', 3600), ['http_code' => 200]];
+                }
+                return ['{"result":"ok"}', ['http_code' => 200]];
+            });
+
+        $module->expects($this->once())
+            ->method('setProjectSetting');
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('POST', 'https://api.example.com/data', 'application/json', [], [], '{"key":"value"}');
+
+        $this->assertEquals(200, $oauth2->getInfo()['http_code']);
+        $this->assertEquals('{"result":"ok"}', $oauth2->getResponse());
+    }
+
+    public function testUsesClientCredentialsForTokenRequest(): void
+    {
+        $module = $this->makeMockModule();
+
+        $capturedCalls = [];
+        $module->method('curlCall')
+            ->willReturnCallback(function ($method, $url, $contentType, $headers, $curlOptions, $payload) use (&$capturedCalls) {
+                $capturedCalls[] = compact('method', 'url', 'contentType', 'headers', 'curlOptions', 'payload');
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse(), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/resource', 'application/json', [], [], '');
+
+        // Verify the token request
+        $tokenCall = $capturedCalls[0];
+        $this->assertEquals('POST', $tokenCall['method']);
+        $this->assertEquals('https://auth.example.com/token', $tokenCall['url']);
+        $this->assertEquals('application/x-www-form-urlencoded', $tokenCall['contentType']);
+        $this->assertStringContainsString('grant_type=client_credentials', $tokenCall['payload']);
+
+        // Verify CURLOPT_USERPWD is set correctly as nested array
+        $this->assertIsArray($tokenCall['curlOptions']);
+        $this->assertCount(1, $tokenCall['curlOptions']);
+        $this->assertEquals(CURLOPT_USERPWD, $tokenCall['curlOptions'][0][0]);
+        $this->assertEquals('test-client-id:test-client-secret', $tokenCall['curlOptions'][0][1]);
+    }
+
+    public function testBearerTokenIncludedInApiRequest(): void
+    {
+        $module = $this->makeMockModule();
+
+        $capturedCalls = [];
+        $module->method('curlCall')
+            ->willReturnCallback(function ($method, $url, $contentType, $headers, $curlOptions, $payload) use (&$capturedCalls) {
+                $capturedCalls[] = compact('method', 'url', 'headers');
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse('my-bearer-token'), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', ['X-Custom: foo'], [], '');
+
+        // The API call should include the Bearer token and preserve existing headers
+        $apiCall = $capturedCalls[1];
+        $this->assertContains('X-Custom: foo', $apiCall['headers']);
+        $this->assertContains('Authorization: Bearer my-bearer-token', $apiCall['headers']);
+    }
+
+    // ---------------------------------------------------------------
+    // Token caching
+    // ---------------------------------------------------------------
+
+    public function testSkipsFetchWhenCachedTokenIsValid(): void
+    {
+        $module = $this->makeMockModule();
+
+        $futureExpiry = (new \DateTime('+1 hour'))->format('Y-m-d H:i:s');
+        $cache = json_encode([
+            'access_token'        => 'cached-token',
+            'access_token_expiry' => $futureExpiry,
+        ]);
+
+        // Only one curlCall expected — the API call, no token fetch
+        $module->expects($this->once())
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url, $contentType, $headers) {
+                $this->assertContains('Authorization: Bearer cached-token', $headers);
+                return ['cached-response', ['http_code' => 200]];
+            });
+
+        // setProjectSetting should NOT be called (no new token to save)
+        $module->expects($this->never())
+            ->method('setProjectSetting');
+
+        $instruction = $this->makeInstruction(['oauth2-cache' => $cache]);
+        $oauth2 = new OAuth2ClientCredentials($module, $instruction, 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+
+        $this->assertEquals('cached-response', $oauth2->getResponse());
+    }
+
+    public function testRefreshesTokenWhenExpiringSoon(): void
+    {
+        $module = $this->makeMockModule();
+
+        // Token expires in 2 minutes — within the 5-minute refresh window
+        $soonExpiry = (new \DateTime('+2 minutes'))->format('Y-m-d H:i:s');
+        $cache = json_encode([
+            'access_token'        => 'expiring-token',
+            'access_token_expiry' => $soonExpiry,
+        ]);
+
+        // Two calls expected: token fetch + API call
+        $module->expects($this->exactly(2))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse('refreshed-token'), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $instruction = $this->makeInstruction(['oauth2-cache' => $cache]);
+        $oauth2 = new OAuth2ClientCredentials($module, $instruction, 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    public function testRefreshesTokenWhenExpired(): void
+    {
+        $module = $this->makeMockModule();
+
+        $pastExpiry = (new \DateTime('-10 minutes'))->format('Y-m-d H:i:s');
+        $cache = json_encode([
+            'access_token'        => 'expired-token',
+            'access_token_expiry' => $pastExpiry,
+        ]);
+
+        $module->expects($this->exactly(2))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse('new-token'), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $instruction = $this->makeInstruction(['oauth2-cache' => $cache]);
+        $oauth2 = new OAuth2ClientCredentials($module, $instruction, 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    // ---------------------------------------------------------------
+    // 401 retry logic
+    // ---------------------------------------------------------------
+
+    public function testRetriesOnceOn401WithFreshToken(): void
+    {
+        $module = $this->makeMockModule();
+
+        $callCount = 0;
+        // Expect 4 calls: token fetch, API (401), token fetch again, API (200)
+        $module->expects($this->exactly(4))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url, $contentType, $headers) use (&$callCount) {
+                $callCount++;
+                if ($url === 'https://auth.example.com/token') {
+                    $token = ($callCount <= 2) ? 'first-token' : 'second-token';
+                    return [$this->makeTokenResponse($token), ['http_code' => 200]];
+                }
+                // First API call returns 401, second succeeds
+                if ($callCount === 2) {
+                    return ['Unauthorized', ['http_code' => 401]];
+                }
+                $this->assertContains('Authorization: Bearer second-token', $headers);
+                return ['{"success":true}', ['http_code' => 200]];
+            });
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('POST', 'https://api.example.com/data', 'application/json', [], [], '{}');
+
+        $this->assertEquals(200, $oauth2->getInfo()['http_code']);
+        $this->assertEquals('{"success":true}', $oauth2->getResponse());
+    }
+
+    public function testDoesNotRetryWhenRetryDisabled(): void
+    {
+        $module = $this->makeMockModule();
+
+        // Expect 2 calls: token fetch, API (401) — no retry
+        $module->expects($this->exactly(2))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse(), ['http_code' => 200]];
+                }
+                return ['Unauthorized', ['http_code' => 401]];
+            });
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '', false);
+
+        $this->assertEquals(401, $oauth2->getInfo()['http_code']);
+    }
+
+    public function testDoesNotRetryOnNon401Errors(): void
+    {
+        $module = $this->makeMockModule();
+
+        // Expect 2 calls: token fetch, API (500) — no retry
+        $module->expects($this->exactly(2))
+            ->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse(), ['http_code' => 200]];
+                }
+                return ['Internal Server Error', ['http_code' => 500]];
+            });
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+
+        $this->assertEquals(500, $oauth2->getInfo()['http_code']);
+    }
+
+    // ---------------------------------------------------------------
+    // Error handling
+    // ---------------------------------------------------------------
+
+    public function testThrowsWhenTokenEndpointReturnsError(): void
+    {
+        $module = $this->makeMockModule();
+
+        $module->method('curlCall')
+            ->willReturn(['{"error":"invalid_client"}', ['http_code' => 401]]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to obtain access token');
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    public function testThrowsWhenTokenResponseMissingFields(): void
+    {
+        $module = $this->makeMockModule();
+
+        $module->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    // Missing expires_in
+                    return [json_encode(['access_token' => 'tok']), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unexpected access token response');
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    public function testThrowsWhenTokenEndpointReturnsNoHttpCode(): void
+    {
+        $module = $this->makeMockModule();
+
+        $module->method('curlCall')
+            ->willReturn(['', []]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to obtain access token');
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    // ---------------------------------------------------------------
+    // Token persistence
+    // ---------------------------------------------------------------
+
+    public function testSavesTokenToProjectSettings(): void
+    {
+        $module = $this->makeMockModule();
+
+        $module->method('curlCall')
+            ->willReturnCallback(function ($method, $url) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse('saved-token', 7200), ['http_code' => 200]];
+                }
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $module->expects($this->once())
+            ->method('setProjectSetting')
+            ->with(
+                'oauth2-cache',
+                $this->callback(function ($value) {
+                    $cached = json_decode($value[0], true);
+                    return $cached['access_token'] === 'saved-token'
+                        && !empty($cached['access_token_expiry']);
+                })
+            );
+
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', [], [], '');
+    }
+
+    // ---------------------------------------------------------------
+    // Headers isolation
+    // ---------------------------------------------------------------
+
+    public function testOriginalHeadersNotMutatedByBearerToken(): void
+    {
+        $module = $this->makeMockModule();
+
+        $capturedApiHeaders = [];
+        $module->method('curlCall')
+            ->willReturnCallback(function ($method, $url, $contentType, $headers) use (&$capturedApiHeaders) {
+                if ($url === 'https://auth.example.com/token') {
+                    return [$this->makeTokenResponse(), ['http_code' => 200]];
+                }
+                $capturedApiHeaders = $headers;
+                return ['ok', ['http_code' => 200]];
+            });
+
+        $originalHeaders = ['Accept: application/json'];
+        $oauth2 = new OAuth2ClientCredentials($module, $this->makeInstruction(), 0);
+        $oauth2->oauth2Call('GET', 'https://api.example.com/data', 'application/json', $originalHeaders, [], '');
+
+        // Original array should not have been modified (PHP passes arrays by value)
+        $this->assertCount(1, $originalHeaders);
+        $this->assertEquals('Accept: application/json', $originalHeaders[0]);
+
+        // But the API call should have received both headers
+        $this->assertCount(2, $capturedApiHeaders);
+        $this->assertContains('Accept: application/json', $capturedApiHeaders);
+        $this->assertContains('Authorization: Bearer fresh-token', $capturedApiHeaders);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Test bootstrap
+ * Stubs out REDCap framework classes so module code can be loaded
+ * without a REDCap installation.
+ */
+
+// Stub AbstractExternalModule so REDCapREST can extend it
+namespace ExternalModules {
+    if (!class_exists('ExternalModules\AbstractExternalModule')) {
+        abstract class AbstractExternalModule {
+            public function getSubSettings($key) { return []; }
+            public function getProjectSetting($key) { return []; }
+            public function setProjectSetting($key, $value) {}
+            public function getSystemSetting($key) { return null; }
+            public function query($sql, $params = []) { return null; }
+            public function escape($value) { return $value; }
+            public function log($message) {}
+        }
+    }
+}
+
+// Stub REDCap class
+namespace {
+    if (!class_exists('REDCap')) {
+        class REDCap {
+            public static function evaluateLogic() { return true; }
+            public static function getData() { return []; }
+            public static function saveData() { return ['errors' => []]; }
+            public static function logEvent() {}
+            public static function isLongitudinal() { return false; }
+            public static function getEventNames() { return ''; }
+            public static function filterHtml($s) { return $s; }
+        }
+    }
+
+    if (!class_exists('Piping')) {
+        class Piping {
+            public static function replaceVariablesInLabel() { return ''; }
+        }
+    }
+
+    if (!function_exists('starts_with')) {
+        function starts_with($haystack, $needle) {
+            return strpos($haystack, $needle) === 0;
+        }
+    }
+
+    if (!function_exists('db_fetch_assoc')) {
+        function db_fetch_assoc($result) { return []; }
+    }
+}


### PR DESCRIPTION
# Add PHPUnit tests for OAuth2 Client Credentials flow

## Summary

This adds a test suite for the OAuth2 Client Credentials implementation to help with ongoing development. It builds on the fixes in #5.

Since the OAuth2 classes can't easily be tested inside a running REDCap instance, the tests mock `REDCapREST` and verify the OAuth2 logic in isolation. This let us catch and validate the fixes in the companion PR without needing a full environment.

## What's included

### Test scaffolding

- `composer.json` — PHPUnit 10 dev dependency with autoloading
- `phpunit.xml` — test suite configuration
- `tests/bootstrap.php` — lightweight stubs for `AbstractExternalModule`, `REDCap`, `Piping`, and helper functions so module code can load outside of REDCap

### Test coverage (13 tests)

**Token acquisition** — verifies a new token is fetched when the cache is empty, that client credentials are sent correctly (POST with `CURLOPT_USERPWD`), and that the Bearer token appears in API request headers.

**Token caching** — confirms the token fetch is skipped when a cached token is still valid, and that refresh happens both within the 5-minute expiry window and after full expiration.

**401 retry** — checks that a single retry occurs with a fresh token on 401, that retry is skipped when disabled, and that non-401 errors (e.g. 500) don't trigger a retry.

**Error handling** — validates exceptions for error HTTP status from the token endpoint, missing fields in the token response, and absent HTTP code.

**Persistence** — verifies token and expiry are saved via `setProjectSetting`.

**Header isolation** — confirms the caller's original headers array isn't modified by the Bearer token injection.

## How to run

```bash
composer install
./vendor/bin/phpunit
```

Requires PHP 8.1+.

## Files changed

| File | Purpose |
|---|---|
| `composer.json` | PHPUnit dependency and autoloading |
| `phpunit.xml` | Test suite configuration |
| `tests/bootstrap.php` | REDCap framework stubs |
| `tests/OAuth2ClientCredentialsTest.php` | 13 test cases |
| `.gitignore` | Added `vendor/`, `composer.lock`, `.phpunit.cache/` |
